### PR TITLE
Specify development dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,9 @@ source "https://rubygems.org"
 
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
+# Specify your gem's dependencies in <GEM_NAME>.gemspec
 gemspec
 
-gem "panolint", github: "panorama-ed/panolint"
-gem "rake", "~> 12.0"
-gem "rspec", "~> 3.0"
+group :development do
+  gem "panolint", github: "panorama-ed/panolint"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,7 +36,7 @@ GEM
       ast (~> 2.4.0)
     rack (2.2.2)
     rainbow (3.0.0)
-    rake (12.3.3)
+    rake (13.0.1)
     rexml (3.2.4)
     rspec (3.9.0)
       rspec-core (~> 3.9.0)
@@ -79,7 +79,7 @@ PLATFORMS
 
 DEPENDENCIES
   panolint!
-  rake (~> 12.0)
+  rake (~> 13.0)
   rspec (~> 3.0)
   template!
 

--- a/template.gemspec
+++ b/template.gemspec
@@ -21,4 +21,7 @@ Gem::Specification.new do |spec|
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
+
+  spec.add_development_dependency "rake", "~> 13.0"
+  spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
Gems differentiate between 'production' and 'development'
dependencies, with the impact that production dependencies
are transitively depended on by any app that depends on
the gem.

Here we move the Rake and RSpec dependencies to be specified
as development dependencies in the gemspec file.

We can't do that for a panolint becauyse it is a git
dependency, so we move it to a 'development' group
in the Gemfile.